### PR TITLE
docs(natspec): correct LibOpContext.run/@param: column is low byte, row is second byte

### DIFF
--- a/src/lib/op/00/LibOpContext.sol
+++ b/src/lib/op/00/LibOpContext.sol
@@ -43,7 +43,7 @@ library LibOpContext {
 
     /// @notice `context` opcode. Reads a value from the context matrix at operand-specified indices.
     /// @param state The interpreter state containing the context matrix.
-    /// @param operand Encodes the row (low byte) and column (second byte) indices.
+    /// @param operand Encodes the column (low byte) and row (second byte) indices.
     /// @param stackTop Pointer to the top of the stack.
     /// @return The new stack top pointer after execution.
     function run(InterpreterState memory state, OperandV2 operand, Pointer stackTop) internal pure returns (Pointer) {
@@ -63,7 +63,7 @@ library LibOpContext {
 
     /// @notice Reference implementation of `context` for testing.
     /// @param state The interpreter state containing the context matrix.
-    /// @param operand Encodes the row (low byte) and column (second byte) indices.
+    /// @param operand Encodes the column (low byte) and row (second byte) indices.
     /// @return outputs The output values to push onto the stack.
     function referenceFn(InterpreterState memory state, OperandV2 operand, StackItem[] memory)
         internal


### PR DESCRIPTION
## Summary

Corrects the `@param operand` NatSpec in `LibOpContext.run` and `LibOpContext.referenceFn`.

`LibSubParse.subParserContext` (the encoder) stores **column at offset 0x23 (low byte)** and **row at offset 0x22 (second byte)**. The old NatSpec said the opposite — "row (low byte) and column (second byte)" — inverting the semantics in documentation.

The actual cell read `state.context[i][j]` where `i = low byte, j = second byte` is always consistent with the encode side, so no runtime behavior is affected. This is a doc-only fix.

Refs rainlanguage/raindex#2671 (item 5 — `@param` column/row inversion in `LibOpContext.run`/`referenceFn`)

## Test plan

- [ ] CI passes (NatSpec-only change, no Solidity logic change)
- [ ] Slither passes