### PR TITLE
Remove submodule-era residue from .soldeerignore

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -7,7 +7,6 @@
 .git
 .github
 .gitignore
-.gitmodules
 .pre-commit-config.yaml
 .prettierignore
 .soldeerignore
@@ -18,9 +17,7 @@ CLAUDE.md
 /dependencies
 /flake.lock
 /flake.nix
-/foundry.lock
 /foundry.toml
-/lib
 /out
 /remappings.txt
 /slither.config.json


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rainlang/issues/553

## What changed

Three lines removed from `.soldeerignore`. That is the whole diff:

```diff
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -7,7 +7,6 @@
 .git
 .github
 .gitignore
-.gitmodules
 .pre-commit-config.yaml
 .prettierignore
 .soldeerignore
@@ -18,9 +17,7 @@ CLAUDE.md
 /dependencies
 /flake.lock
 /flake.nix
-/foundry.lock
 /foundry.toml
-/lib
 /out
 /remappings.txt
 /slither.config.json
```

## The property being applied

`.soldeerignore` is a publish **filter**, not a description of the tree. An entry naming a file that is absent today is a forward-looking rule — it keeps that file out of the soldeer package if anyone ever adds it — so "this path does not exist" is **not** on its own a reason to delete an entry. Deleting one on that basis removes protection.

These three qualify on a different property: each names part of the **git-submodule dependency layout**, which this repo does not use and cannot go back to. The rule they encode can never fire again, so there is no protection to lose.

- **`.gitmodules`** and **`/lib`** are the submodule vendoring layout itself. Rainix CI runs a [`no-submodules`](https://github.com/rainlanguage/rainix/blob/main/.github/actions/no-submodules/action.yml) check that fails on a root `.gitmodules` or any committed gitlink, so no future commit can reintroduce either path for these entries to filter. Ran that exact check against this branch: `no-submodules: clean`, and `git ls-files --stage | grep ^160000` is empty. Separately, `foundry.toml` sets `libs = ['dependencies']`, so forge resolves under `dependencies/` and never creates `lib/` on its own either. The `/lib` pattern is rooted and never matched `src/lib/`, which is untouched.
- **`/foundry.lock`** is Foundry's git-submodule lockfile: it records the commit each dependency vendored under `lib/` is pinned to, so `forge install` / `forge update` can restore identical submodule revisions. It is only meaningful alongside that same banned layout. `soldeer.lock` is the live lockfile here.

## Not touched, on purpose

Every other entry stays, **including the ones with no file on disk today**, because absence is not the test:

- `.DS_Store` and `/deployments` are absent from a clean checkout by design — OS junk and deploy-script output that IS present when `soldeer push` runs. They still filter. Likewise `.pre-commit-config.yaml`, `/out`, `/cache` and `/dependencies`, which are generated at `forge soldeer install` / `forge build` time.
- Audited the remaining entries for the misspelling case (an entry that was meant to protect a real file but typos its name, where the fix is to correct it in place, not drop it). There are none here: every other entry resolves to a real path, and the only two absent are the two above, which are exempt by design rather than by typo.
- `REUSE.toml` is the opposite kind of file — its annotations describe files that actually exist — but it needs no change either: it annotates none of the three removed paths, and every path it does annotate resolves.
- `CLAUDE.md` makes no stale claim that dependencies are submodules under `lib/`. Left alone.
- The same residue in other rainlanguage repos is out of scope per the issue. `flow` and `rain.tier.interface` genuinely still use submodules and must keep their entries.

## QA

- **Discriminating tests**: `forge soldeer push --dry-run` packaging-equivalence check, run in `sol-shell` at the CI-pinned rainix SHA. Packed the repo with the new `.soldeerignore` and with `main`'s, then compared every zip entry by name + uncompressed size + CRC32. **525 entries both ways, listings byte-identical.** Publishing is the only observable `.soldeerignore` has — it decides nothing but what `soldeer push` uploads, and `rainix-static soldeer-gate` hashes exactly that packed content — so an identical listing is proof the removal is inert today. There is no code in this diff, so no test fails on base: the correct expected result is a null, and the control below is what gives that null meaning.
- **Mutations applied**: no executable code in the diff, so no source line to mutate. The equivalent — a positive control proving the equivalence check is not vacuously green — was applied: appending `/README.md` (an ignore for a file that **does** exist) to `.soldeerignore` dropped the packed set from 525 to 524 entries, losing exactly `README.md 4458 eed4a9dd`. The harness does detect a live ignore line; it reported no difference for these three because their rule is dead, not because it cannot see one.
- **Oracle**: for the forward-looking half of the claim — can the filtered path ever come back? — the oracle is rainix's own `no-submodules` binary plus `foundry.toml`'s `libs = ['dependencies']`, both external to this repo's `.soldeerignore`. For the inert-today half, the filesystem and git index (`ls`, `git ls-files --stage`). Expected packed contents derive from what is on disk, never from the ignore file under test.
- **Category check**: the issue asks for (a) `.soldeerignore` lines 10, 21 and 23 removed, (b) no reference to `.gitmodules`, `lib/` or `foundry.lock` anywhere in the tree outside `dependencies/`, (c) CI green on `rainix-sol` test / static / legal. Covered a, b and c. (b) verified by grepping the whole tree excluding `.git/` and `dependencies/`: the only two hits before this change were `.soldeerignore:10` and `.soldeerignore:21`; every `lib` hit is `src/lib/` or a dependency's `src/lib/`, neither of which the rooted `/lib` pattern ever matched. Zero hits after.

## Verification

Run locally in `sol-shell` at the CI-pinned rainix SHA `53e96a7d0a97d7c7c75c3b2412521324776fdac6`, and in CI:

- **legal** — `reuse lint`: 469/469 files with copyright and license information, 0 missing, compliant with REUSE 3.3. Green locally and in CI. This was the job most at risk from the change, since dropping a `REUSE.toml` annotation is what breaks it — hence leaving `REUSE.toml` untouched.
- **static** — green in CI. Locally: `forge fmt --check` clean, `slither .` clean, `no-submodules` clean.
- **test** — CI red, but **pre-existing on `main` and identical**, not caused by this change. `main` at `a6b7ad73` (this branch's merge base) fails the same 5 tests with the same counts:

  | | `main` a6b7ad73 | this branch |
  |---|---|---|
  | failing | 5 | 5 |
  | passing | 1589 | 1589 |
  | tests | `testProdDeployArbitrum`, `testProdDeployBase`, `testProdDeployBaseSepolia`, `testProdDeployFlare`, `testProdDeployPolygon` — all `[FAIL: Interpreter not deployed]` | identical |

  These are fork tests asserting the prod interpreter is live on each chain; they fail because it is not deployed there, which no `.soldeerignore` edit can affect. `rainix-sol` has been red on `main` on every run since at least 2026-07-03. Zero test delta from this PR. **This is a real pre-existing defect and is not fixed here** — it needs a deployment, not a code change, and is outside the scope of #553.

  (A local `forge test` additionally fails on unset `<NETWORK>_RPC_URL` env vars, which CI's `rpc-preflight` step supplies; CI is authoritative for this job.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore settings so `.gitmodules`, `foundry.lock`, and the `lib` directory are no longer excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->