### PR TITLE
Drop foundry.toml release metadata: version intent lives in next-v tags (rainix#335)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,3 @@
-[package]
-name = "rainlang"
-version = "0.1.8"
-
 [profile.default]
 src = 'src'
 out = 'out'


### PR DESCRIPTION
Deletes the foundry.toml release-metadata section per https://github.com/rainlanguage/rainix/issues/335. Since https://github.com/rainlanguage/rainix/pull/336 merged, rainix-autopublish derives the publish version from the Soldeer registry plus `next-v*` git tags; the section is never read, and the autopublish content gate excludes it (including its attached comment block) from the content hash, so this deletion is content-neutral: it cannot mint a spurious release and changes no behavior.

Heavyweight repo: verified locally with `nix develop -c reuse lint` (green) and `forge soldeer install` + `forge build` only ("Compiler run successful", pre-existing forge-lint warnings untouched); the full suite is left to CI per the sweep work order.

## QA
- Discriminating tests: n/a - config-metadata deletion; nothing reads the section since rainix#336 (local `reuse lint` green + `forge build` successful; full suite delegated to CI)
- Mutations applied: n/a - no code changed
- Oracle: rainix#336 gate semantics (section excluded from content hash; version from registry + next-v tags)
- Category check: issue asks removal of release metadata from consumers; covered exactly for this repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed package metadata from the project configuration.
  * Existing build, dependency, compiler, filesystem, RPC, and verification settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->