### PR TITLE
Bump [package].version to 0.1.9 for the solmem-chain release

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rainlang"
-version = "0.1.8"
+version = "0.1.9"
 
 [profile.default]
 src = 'src'


### PR DESCRIPTION
#560 shipped the solmem 0.1.26 dep chain without bumping `[package].version`, and the Package Release gate refuses to publish a version that is not ahead of the published revision (its exact error on the July run: "foundry.toml [package].version (0.1.8) is not ahead of the published revision (0.1.8)").

Patch is honest for this release: the interface migration swaps which package provides the same types (rainlang-interface 0.2.5's source delta vs the orphaned rain-interpreter-interface is import pins only), and the solmem/datacontract/extrospection/math-binary bumps move internals and generated pointers, not rainlang's own API.

Note: publish is ALSO blocked by a dead credential — the repo-level `PUBLISH_PRIVATE_KEY` (set 2026-05-26) shadows the working org-level secret and its counterpart key no longer exists anywhere (today's run 32590826123 dies at checkout with "Permission denied (publickey)"). The repo secret needs deleting so the org secret flows through, as it does on every repo that published today.

## QA
- Discriminating tests: n/a — one-line version metadata edit in foundry.toml; no executable code in the diff, so no test can distinguish it. The release gate itself discriminates: it hard-fails any version not strictly ahead of the published 0.1.8.
- Mutations applied: n/a — no logic to mutate; the only possible mutation (a different version string) is exactly what the release gate adjudicates.
- Oracle: the soldeer registry's published revision list (rainlang 0.1.8 latest, 2026-07-03) and the Package Release gate's own error text demanding the next unpublished version.
- Category check: unblocks the #560 release chain; covers exactly the version-bump requirement, nothing else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.1.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->