### PR TITLE
Expose the deploy reusable's legacy and verify inputs

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -12,9 +12,23 @@ on:
           - interpreter
           - expression-deployer
           - rainlang
+      legacy:
+        description: >-
+          Send type-0 (legacy) transactions. HyperEVM's RPC rejects the fee-history ranges EIP-1559 estimation asks for, and one dispatch broadcasts to every supported network, so a run that has to reach HyperEVM needs this. Type-0 works everywhere.
+        required: false
+        type: boolean
+        default: false
+      verify:
+        description: >-
+          Verify on the block explorer after broadcasting. Turn it off when the verification retry loop would outlast the deploy; `Manual sol verify` repairs verification later without re-broadcasting.
+        required: false
+        type: boolean
+        default: true
 jobs:
   deploy:
     uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
     with:
       suite: ${{ inputs.suite }}
+      legacy: ${{ inputs.legacy }}
+      verify: ${{ inputs.verify }}
     secrets: inherit

--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -12,12 +12,6 @@ on:
           - interpreter
           - expression-deployer
           - rainlang
-      legacy:
-        description: >-
-          Send type-0 (legacy) transactions. HyperEVM caps eth_feeHistory at a 5-block window whatever range is asked for; set this if EIP-1559 estimation cannot work with that. Type-0 works everywhere.
-        required: false
-        type: boolean
-        default: false
       verify:
         description: >-
           Verify on the block explorer after broadcasting. Turn it off when the verification retry loop would outlast the deploy; `Manual sol verify` repairs verification later without re-broadcasting.
@@ -29,6 +23,5 @@ jobs:
     uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
     with:
       suite: ${{ inputs.suite }}
-      legacy: ${{ inputs.legacy }}
       verify: ${{ inputs.verify }}
     secrets: inherit

--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -14,7 +14,7 @@ on:
           - rainlang
       legacy:
         description: >-
-          Send type-0 (legacy) transactions. HyperEVM's RPC rejects the fee-history ranges EIP-1559 estimation asks for, and one dispatch broadcasts to every supported network, so a run that has to reach HyperEVM needs this. Type-0 works everywhere.
+          Send type-0 (legacy) transactions. HyperEVM caps eth_feeHistory at a 5-block window whatever range is asked for; set this if EIP-1559 estimation cannot work with that. Type-0 works everywhere.
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
`Manual sol artifacts` passes only `suite` to the rainix reusable, so two of its inputs are unreachable from a dispatch. Both are worth having before this repo's first deploy under #563.

**`verify`** — the reusable runs `--verify --retries 40 --delay 15`, up to 10 minutes of retries per contract per network. On raindex today two dispatches sat in that loop for over 100 minutes without reaching their broadcast, with no pending transaction on chain; re-dispatching with `verify: false` landed both within minutes, and `Manual sol verify` repaired verification afterwards without re-broadcasting. This is the input that unblocked that.

**`legacy`** — the escape hatch for type-0 transactions, matching what raindex exposes. Stated precisely, because the reusable's own description overstates it: HyperEVM's RPC does **not** reject `eth_feeHistory`. Measured against `rpc.hyperliquid.xyz/evm` today, it answers, and `eth_maxPriorityFeePerGas` returns a value — but it caps the window at 5 blocks regardless of the range requested (5, 20 and 50 all return 6 `baseFeePerGas` entries). Whether forge's estimation tolerates that truncation is untested here: every raindex dispatch today passed `legacy: true`, so there is no evidence either way about `legacy: false`. The input is exposed so the question can be answered by dispatch rather than by assumption.

Defaults match the reusable's own (`legacy: false`, `verify: true`), so existing dispatch behaviour is unchanged.

This is the last repo-side blocker for rainlang's first deploy. What follows is on-chain work, not code: four of the five suites have no code at their current addresses on any network (only `RainlangStore` survives, because the solmem bump in #560 left its bytecode untouched while moving the parser's), so they need deploying in dependency order — parser/store/interpreter, then expression-deployer, then rainlang — before `cutRelease()` can freeze `0_1_9` and arm the chain check. Both external dependencies (log tables, TOFU) already have code on all seven networks.

## QA

- Discriminating tests: n/a — a workflow input passthrough has no test harness here, and CI does not execute `workflow_dispatch` paths. The observable check is that the dispatch form renders both inputs and forwards them; that requires a human dispatch by design.
- Mutations applied: n/a — no logic in the diff. Each wiring line either forwards its input or the workflow fails to parse.
- Oracle: `rainix-manual-sol-artifacts.yaml`'s own `workflow_call` input list, which declares both with the defaults used here. The `verify` behaviour was established empirically on raindex today (hung runs versus a `verify: false` re-dispatch that completed); the HyperEVM fee-history behaviour was measured directly against the RPC rather than taken from the reusable's description, which is why the claim above is narrower than that description.
- Category check: no linked issue. Covers the two missing passthroughs only — no default changes, no deploy-script changes, nothing affecting a running dispatch.
