### PR TITLE
Drop the Build Environment section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,20 +4,6 @@ Guidance for Claude Code in this repo. This file takes precedence over session
 summaries — re-read it as written rather than trusting a summary's framing of
 what a process means.
 
-## Build Environment
-
-Nix flakes only: run everything as `nix develop -c <cmd>`. Once per session, in
-order, before any build or test:
-
-```bash
-nix develop -c rainix-sol-prelude
-nix develop -c rainix-rs-prelude
-nix develop -c rainlang-prelude   # generates meta/ needed by the sol build
-```
-
-Common tasks (all via `nix develop -c`): `rainix-sol-test`, `rainix-sol-static`,
-`rainix-rs-test`, `rainix-rs-static`, `test-wasm-build`.
-
 ## Generated code
 
 `script/Build.sol` writes ALL of it. Never hand-edit:


### PR DESCRIPTION
Deletes the `## Build Environment` section. Build and test invocation is an org standard carried by rainix, not something a repo restates — and this repo's restatement had gone stale.

Every command it named is gone from rainix. At the pinned rev, `sol-tasks` is `[rainix-sol-artifacts]` only; `nix develop -c rainix-sol-prelude` fails with `exec: rainix-sol-prelude: not found`, and `rainix-rs-prelude`, `rainix-sol-test`, `rainix-sol-static`, `rainix-rs-test` and `test-wasm-build` went the same way. An agent following the section could not build. The lines date to `4ddba8de` (February), so this is not residue from the #563 migration.

Nothing replaces it. What CI actually runs is in `.github/workflows/`, which is the authority a reader should reach for, and the org convention is that agent context carries only what the code and CI cannot show.

`nix develop -c rainlang-prelude` survives under `## Generated code`, where it belongs: that task is defined in this repo's own flake, and the regeneration loop it starts is repo-specific rather than an org standard.

CLAUDE.md goes 3966 → 3535 bytes against the 4096 `agent-context-cap`, so this is a net trim.

## QA

- Discriminating tests: n/a — documentation-only diff with no executable content. The check that matters was run by hand and is what motivated the deletion: `nix develop -c rainix-sol-prelude` errors `not found` at the pinned rainix rev, so the documented sequence cannot be followed.
- Mutations applied: n/a — no logic in the diff.
- Oracle: rainix's own `sol-tasks` definition at the pinned rev, and `.github/workflows/` for what CI actually invokes — both independent of this file.
- Category check: no linked issue; found while cutting the 0.1.9 release and deliberately kept out of that PR so a doc rewrite would not ride along with a release freeze. Covers the stale section only; the `rainlang-prelude` reference under Generated code is verified still valid and left alone.
