### PR TITLE
Add the Manual sol verify caller workflow

### DIFF
--- a/.github/workflows/manual-sol-verify.yaml
+++ b/.github/workflows/manual-sol-verify.yaml
@@ -1,0 +1,59 @@
+name: Manual sol verify
+# Explorer source verification for a suite that is ALREADY on chain, run by
+# hand.
+#
+# `manual-sol-artifacts.yaml` submits source only for what its own run
+# broadcast, and the broadcast is idempotent: a rerun against networks that
+# already hold the code broadcasts nothing, so there is nothing for `--verify`
+# to submit and the run is green having verified nothing. A deploy that landed
+# and then went unverified — a bad explorer key, a rate limit, an explorer that
+# was down, or `verify: false` because the retry loop would have outlasted the
+# deploy — is repaired here rather than by re-dispatching the deploy.
+#
+# Deliberately `workflow_dispatch` only, like the deploy. Unlike the deploy this
+# never broadcasts and never reads `DEPLOYMENT_KEY`: `forge verify-contract`
+# talks to the explorer API and nothing else, so it is safe to re-run and is
+# already a no-op ("already verified") against an explorer that has the source.
+on:
+  workflow_dispatch:
+    inputs:
+      contract:
+        type: string
+        required: true
+        description: |
+          Artifact path of the contract to submit, `path:Contract`. Paired with
+          `address` on the `manual verification command:` line
+          `script/Deploy.sol` prints for every network, whether it deployed
+          there or skipped it, so a run of the deploy is where both values come
+          from. They are also the `artifactPath` and the generated
+          `DEPLOYED_ADDRESS` of the five suites in
+          `src/abstract/RainlangDeploySuites.sol`.
+      address:
+        type: string
+        required: true
+        description: |
+          The deployed address. One value for every network, because the Zoltu
+          factory derives one address from the creation code.
+      networks:
+        type: string
+        required: true
+        default: arbitrum base base-sepolia mainnet flare hyperliquid polygon
+        description: |
+          Which explorers to submit to. FOUNDRY's chain names, not the
+          `[rpc_endpoints]` aliases, and the two differ on three of the seven:
+          the aliases `base_sepolia`, `ethereum` and `hyperevm` are rejected
+          outright, and the chain names are `base-sepolia`, `mainnet` and
+          `hyperliquid`. The `manual verification command:` line is NOT a source
+          for this field — it prints `--chain` with the alias it broadcast
+          under, which is the spelling that gets rejected here. The default is
+          `LibRainDeploy.supportedNetworks()` spelled the working way, i.e.
+          every network `script/Deploy.sol` broadcasts to, so it has to move
+          when that does.
+jobs:
+  verify:
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-verify.yaml@main
+    with:
+      contract: ${{ inputs.contract }}
+      address: ${{ inputs.address }}
+      networks: ${{ inputs.networks }}
+    secrets: inherit


### PR DESCRIPTION
## Why

Every one of the five `sol-v0.1.9` deploys ran with `verify: false` — the verification retry loop was hanging the runs — so all five contracts are live on all seven networks with no source on any explorer:

| run | suite | contract | address |
| --- | --- | --- | --- |
| [32744942650](https://github.com/rainlanguage/rainlang/actions/runs/32744942650) | `parser` | `src/concrete/RainlangParser.sol:RainlangParser` | `0x0030FF8D5386EF3AdDD5CcaCc6DdB9c3D0C5adaA` |
| [32745425210](https://github.com/rainlanguage/rainlang/actions/runs/32745425210) | `store` | `src/concrete/RainlangStore.sol:RainlangStore` | `0x1Aa775533E28B1D843e1A589034984E3a62005DC` |
| [32745911110](https://github.com/rainlanguage/rainlang/actions/runs/32745911110) | `interpreter` | `src/concrete/RainlangInterpreter.sol:RainlangInterpreter` | `0x4c52eee7Fb6aeD0F1a30130d96d02409D9d886cf` |
| [32746387398](https://github.com/rainlanguage/rainlang/actions/runs/32746387398) | `expression-deployer` | `src/concrete/RainlangExpressionDeployer.sol:RainlangExpressionDeployer` | `0xb90c299a8321fbdd8D0F367e560f5341F840dA3F` |
| [32746975122](https://github.com/rainlanguage/rainlang/actions/runs/32746975122) | `rainlang` | `src/concrete/Rainlang.sol:Rainlang` | `0x820FB8ae43350f6F4F60117955751b0a6777aC54` |

Each address is the `DEPLOYED_ADDRESS` in the matching `src/generated/0_1_9/` snapshot; each artifact path is the matching `artifactPath` in `src/abstract/RainlangDeploySuites.sol`.

Re-dispatching `Manual sol artifacts` cannot repair this. The deploy is deterministic and therefore idempotent: a rerun against networks that already hold the code broadcasts nothing, `--verify` gets nothing to submit, and the run goes green having verified nothing. `manual-sol-artifacts.yaml`'s own `verify` input description already names `Manual sol verify` as the repair path — this PR is that workflow, which the repo did not have.

## What

One file. A thin `workflow_dispatch` caller over `rainlanguage/rainix/.github/workflows/rainix-manual-sol-verify.yaml@main`, the same shape as the one in `rainlanguage/rain.deploy`. It never broadcasts and never reads `DEPLOYMENT_KEY` — `forge verify-contract` talks to the explorer API and nothing else — so it is safe to re-run and is a no-op against an explorer that already holds the source.

### The `networks` default is FOUNDRY chain names, not the RPC aliases

`forge verify-contract --chain` takes foundry's own chain names. Three of this repo's seven `[rpc_endpoints]` aliases are spelled differently and are rejected outright:

| `[rpc_endpoints]` alias | `--chain` name |
| --- | --- |
| `base_sepolia` | `base-sepolia` |
| `ethereum` | `mainnet` |
| `hyperevm` | `hyperliquid` |

The other four (`arbitrum`, `base`, `flare`, `polygon`) are spelled the same in both.

This is a live trap, not a theoretical one: the `manual verification command:` line `LibRainDeploy` prints after each broadcast emits `--chain` with the **alias** it broadcast under — e.g. `forge verify-contract --chain hyperevm 0x820FB8ae43350f6F4F60117955751b0a6777aC54 src/concrete/Rainlang.sol:Rainlang`. Copying that line's `--chain` value into this input is the exact mistake that gets rejected, so the input description says not to.

## Dispatching it

After merge, once per contract:

```
gh workflow run "Manual sol verify" --repo rainlanguage/rainlang \
  -f contract=src/concrete/RainlangParser.sol:RainlangParser \
  -f address=0x0030FF8D5386EF3AdDD5CcaCc6DdB9c3D0C5adaA
```

`networks` defaults to all seven, so it is only passed to narrow a run.

Not merged by me. It deploys nothing, but it is the thing that gets pointed at seven explorers, so it wants a human on the button.

## QA

- Discriminating tests: n/a, with the reason. The diff is one declarative GitHub workflow file with no executable logic of its own, and this repo has no harness that executes workflow YAML (no actionlint, no yamlfmt, no workflow lint job in CI) — a test added here would assert the file's own text back at itself. What was checked instead is below, and all of it is against sources outside the file.
- Mutations applied: n/a, with the reason. There are no code lines to mutate; GitHub is the consumer, and the substantive guard already lives upstream in `rainix-manual-sol-verify.yaml`, which refuses a blank `contract`/`address`/`networks` rather than looping zero times and exiting green. What this file *can* get wrong is its data — the artifact paths and the `networks` default — so both were checked against an independent oracle instead: (1) `arbitrum base base-sepolia mainnet flare hyperliquid polygon` are all seven accepted by `forge verify-contract --chain` (foundry nightly `43923a4`, from `rainix#sol-shell`); (2) `base_sepolia`, `ethereum` and `hyperevm` are all three rejected by that same binary with `error: invalid value '<name>' for '--chain <CHAIN>'`, before any network call — so the default is not merely plausible, the alias spellings it avoids are demonstrably fatal; (3) the file parses (`yq`).
- Oracle: two independent sources that agree, neither of them this file. (1) The five deploy runs' own `manual verification command:` lines, printed by `LibRainDeploy` from the values it actually broadcast under, read out of the run logs linked in the table above. (2) The committed `src/generated/0_1_9/*.sol` `DEPLOYED_ADDRESS` constants and the `artifactPath` fields in `src/abstract/RainlangDeploySuites.sol`. All five artifact-path/address pairs match across both. For the chain names the oracle is foundry's own `--chain` parser, as above — not the docs, and not the rain.deploy template this was copied from.
- Category check: the ask is (a) add the `Manual sol verify` caller, (b) get the `networks` default onto FOUNDRY chain names rather than the RPC aliases. Covered a, b — (a) is the file, (b) is the default plus the input description that stops the next person copying `--chain` off the deploy's printed line. Nothing else in the ask; no contract is verified by this PR, only made verifiable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for verifying deployed contract source code.
  * Supports selecting the contract artifact, deployed address, and target networks.
  * Verification runs without broadcasting transactions or requiring deployment credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->