### PR TITLE
Rename the Git is clean job id to git-clean

### DIFF
--- a/.github/workflows/git-clean.yaml
+++ b/.github/workflows/git-clean.yaml
@@ -1,7 +1,7 @@
 name: Git is clean
 on: [push]
 jobs:
-  copy-artifacts:
+  git-clean:
     # Shared reusable (rainix#201): rebuild the committed artifacts from
     # committed sources — `script/Build.sol`, `forge build`, CopyArtifacts,
     # `forge fmt` — then `git diff --exit-code`. This is what makes the

--- a/script/lib/LibCopyArtifacts.sol
+++ b/script/lib/LibCopyArtifacts.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.25;
 import {Vm} from "forge-std-1.16.1/src/Vm.sol";
 
 /// @notice Shared logic between `script/CopyArtifacts.sol` (writes the
-/// committed ABI). The `copy-artifacts` CI job runs that writer then
+/// committed ABI). The `git-clean` CI job runs that writer then
 /// `git diff --exit-code`, so the committed copies are asserted fresh by
 /// the absence of drift.
 library LibCopyArtifacts {


### PR DESCRIPTION
Closes #571

The org's currency check has one file name, one workflow name and three job ids. #571 standardises on `git-clean`. This repo needed the **job id only** — `.github/workflows/git-clean.yaml` already carried `name: Git is clean`.

```diff
 jobs:
-  copy-artifacts:
+  git-clean:
```

The job id is the **first** segment of what renders in the checks list. On `main` the context is `copy-artifacts / copy-artifacts`; on this PR it is `git-clean / copy-artifacts`. The trailing segment is the job id *inside* rainix's `rainix-copy-artifacts.yaml` and the issue puts that out of scope. The two repos the issue calls fully conformant (rain.solver, rain.uniswap) render a bare `git-clean` only because they inline the steps instead of calling the reusable, so collapsing this to one segment would be a rainix-side change, not a consumer-side one.

**Not renamed:** `uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main`. rainix *defines* that reusable rather than consuming it; renaming it would break every consumer's `uses:` line.

**Branch protection:** checked before renaming. `main` *is* protected here, but its required status checks are `rainix-sol / test / test` and `rs-test / rs-test (ubuntu-latest)` — `copy-artifacts` is not among them — and no ruleset applies to `main` (`rules/branches/main` returns `[]`). So the rename does not silently stop a required check being required. No protection change is needed and none was made.

**Also updated:** `script/lib/LibCopyArtifacts.sol`'s NatSpec named this repo's job as `copy-artifacts`, which points at a job id that no longer exists after the rename. Comment-only; no artifact impact. `script/CopyArtifacts.sol`'s "copy-artifacts determinism check" reads as the script pipeline rather than the job id, and is left alone.

## QA
- Discriminating tests: n/a — the diff changes a GitHub Actions job id (and, where present, prose naming that id). No test in this repo reads a workflow job id, so no test can discriminate. The discriminator is this PR's own checks list: it renders the job as `git-clean`, which is the assertion the issue makes.
- Mutations applied: n/a — nothing executable changed. The YAML key is consumed by GitHub Actions, not by the repo's build or test code, and the doc/NatSpec edits are comments; there is no line a mutation could survive in.
- Oracle: rainlanguage/rainlang#571, which states the target triple independently of this diff (file `.github/workflows/git-clean.yaml`, workflow `name: Git is clean`, job id `git-clean`), plus GitHub's own rendering of the job id in this PR's checks list and the GitHub API's branch-protection and rules responses for `main`.
- Category check: the issue asks for three things — file name, workflow name, job id. Read on `main` before changing anything, this repo already had the file name and the workflow name, and the job id was `copy-artifacts`; that job id is what this PR changes, so all three are covered. The issue's precondition — check branch protection for a required `copy-artifacts` context before renaming — was carried out and its result is recorded above.
