### PR TITLE
Spell the pinned forge-std and rain-sol-codegen versions in every import

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -36,28 +36,6 @@ fs_permissions = [
   { access = "read", path = "./out" },
 ]
 
-remappings = [
-  # `rain-deploy` 0.1.7, and the `rain-sol-codegen` 0.1.36 it is built on, spell
-  # forge-std as `forge-std-1.16.2/`; this repo's own sources and several of its
-  # other dependencies still spell it `forge-std-1.16.1/`. Soldeer installs ONE
-  # version per package name, so the older prefix is aliased onto the installed
-  # one. Not cosmetic: two forge-std copies in one compilation are two DISTINCT
-  # `Vm` types, and a `vm` handed from one library to another would not type
-  # check.
-  #
-  # These live here rather than in `remappings.txt` because `forge soldeer
-  # install` owns that file and regenerates it from the installed set.
-  "forge-std-1.16.1/=dependencies/forge-std-1.16.2/",
-  # Same, for `rain-sol-codegen`. `rain-deploy` 0.1.7 needs 0.1.36, while this
-  # repo and `rainlang-interface` 0.2.5 import the `IParserToolingV1` /
-  # `ISubParserToolingV1` / `IOpcodeToolingV1` / `IIntegrityToolingV1`
-  # interfaces under the `rain-sol-codegen-0.1.0/` prefix. Those four interfaces
-  # are byte-identical between the two versions bar `pure` widening to `view` on
-  # three functions, which an implementation is free to narrow again, so nothing
-  # here moves any contract's bytecode.
-  "rain-sol-codegen-0.1.0/=dependencies/rain-sol-codegen-0.1.36/",
-]
-
 gas_limit = "18446744073709551615"
 
 [dependencies]

--- a/script/Build.sol
+++ b/script/Build.sol
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Script} from "forge-std-1.16.1/src/Script.sol";
-import {LibCodeGen} from "rain-sol-codegen-0.1.0/src/lib/LibCodeGen.sol";
-import {LibFs} from "rain-sol-codegen-0.1.0/src/lib/LibFs.sol";
+import {Script} from "forge-std-1.16.2/src/Script.sol";
+import {LibCodeGen} from "rain-sol-codegen-0.1.36/src/lib/LibCodeGen.sol";
+import {LibFs} from "rain-sol-codegen-0.1.36/src/lib/LibFs.sol";
 import {LibGenParseMeta} from "rainlang-interface-0.2.8/src/lib/codegen/LibGenParseMeta.sol";
 import {
     RainlangReferenceExtern,

--- a/script/BuildAuthoringMeta.sol
+++ b/script/BuildAuthoringMeta.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Script} from "forge-std-1.16.1/src/Script.sol";
+import {Script} from "forge-std-1.16.2/src/Script.sol";
 import {LibRainlangReferenceExtern} from "../src/concrete/extern/RainlangReferenceExtern.sol";
 
 /// @title BuildAuthoringMeta

--- a/src/abstract/BaseRainlangExpressionDeployer.sol
+++ b/src/abstract/BaseRainlangExpressionDeployer.sol
@@ -12,7 +12,7 @@ import {IDescribedByMetaV1} from "rain-metadata-0.1.0/src/interface/IDescribedBy
 import {LibIntegrityCheck} from "../lib/integrity/LibIntegrityCheck.sol";
 import {LibInterpreterStateDataContract} from "../lib/state/LibInterpreterStateDataContract.sol";
 import {LibAllStandardOps} from "../lib/op/LibAllStandardOps.sol";
-import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IIntegrityToolingV1.sol";
+import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IIntegrityToolingV1.sol";
 import {BaseRainlangParser} from "./BaseRainlangParser.sol";
 
 /// @title BaseRainlangExpressionDeployer

--- a/src/abstract/BaseRainlangExtern.sol
+++ b/src/abstract/BaseRainlangExtern.sol
@@ -10,8 +10,8 @@ import {
     ExternDispatchV2,
     StackItem
 } from "rainlang-interface-0.2.8/src/interface/IInterpreterExternV4.sol";
-import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IIntegrityToolingV1.sol";
-import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IOpcodeToolingV1.sol";
+import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IIntegrityToolingV1.sol";
+import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IOpcodeToolingV1.sol";
 import {ExternOpcodeOutOfRange, ExternPointersMismatch, ExternOpcodePointersEmpty} from "../error/ErrExtern.sol";
 import {OPCODE_FUNCTION_POINTER_SHIFT} from "../lib/eval/LibEval.sol";
 

--- a/src/abstract/BaseRainlangInterpreter.sol
+++ b/src/abstract/BaseRainlangInterpreter.sol
@@ -15,7 +15,7 @@ import {
     EvalV4,
     StackItem
 } from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
-import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IOpcodeToolingV1.sol";
+import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IOpcodeToolingV1.sol";
 import {OddSetLength} from "../error/ErrStore.sol";
 import {ZeroFunctionPointers} from "../error/ErrEval.sol";
 

--- a/src/abstract/BaseRainlangParser.sol
+++ b/src/abstract/BaseRainlangParser.sol
@@ -12,7 +12,7 @@ import {LibParsePragma} from "../lib/parse/LibParsePragma.sol";
 import {LibAllStandardOps} from "../lib/op/LibAllStandardOps.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseInterstitial} from "../lib/parse/LibParseInterstitial.sol";
-import {IParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IParserToolingV1.sol";
+import {IParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IParserToolingV1.sol";
 
 /// @dev The depth the parse meta is built at, for every parser built over the
 /// standard ops' authoring meta.

--- a/src/abstract/BaseRainlangSubParser.sol
+++ b/src/abstract/BaseRainlangSubParser.sol
@@ -14,8 +14,8 @@ import {LibParse, OperandV2} from "../lib/parse/LibParse.sol";
 import {LibParseMeta} from "rainlang-interface-0.2.8/src/lib/parse/LibParseMeta.sol";
 import {LibParseOperand} from "../lib/parse/LibParseOperand.sol";
 import {IDescribedByMetaV1} from "rain-metadata-0.1.0/src/interface/IDescribedByMetaV1.sol";
-import {IParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IParserToolingV1.sol";
-import {ISubParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/ISubParserToolingV1.sol";
+import {IParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IParserToolingV1.sol";
+import {ISubParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/ISubParserToolingV1.sol";
 import {SubParserIndexOutOfBounds} from "../error/ErrSubParse.sol";
 
 /// @dev This is a placeholder for the subparser function pointers.

--- a/test/abstract/OpTest.sol
+++ b/test/abstract/OpTest.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 // Exported for convenience in op tests.
 //forge-lint: disable-next-line(unused-import)
-import {Test, stdError} from "forge-std-1.16.1/src/Test.sol";
+import {Test, stdError} from "forge-std-1.16.2/src/Test.sol";
 import {LibMemCpy} from "rain-solmem-0.1.28/src/lib/LibMemCpy.sol";
 import {MemoryKV} from "rain-lib-memkv-0.1.0/src/lib/LibMemoryKV.sol";
 import {LibUint256Array} from "rain-solmem-0.1.28/src/lib/LibUint256Array.sol";
@@ -31,7 +31,7 @@ import {LibNamespace} from "rainlang-interface-0.2.8/src/lib/ns/LibNamespace.sol
 import {ExponentOverflow, CoefficientOverflow} from "rain-math-float-0.1.1/src/error/ErrDecimalFloat.sol";
 import {LibTOFUTokenDecimals} from "rain-tofu-erc20-decimals-0.1.1/src/lib/LibTOFUTokenDecimals.sol";
 
-import {console2} from "forge-std-1.16.1/src/console2.sol";
+import {console2} from "forge-std-1.16.2/src/console2.sol";
 import {Float, LibDecimalFloat} from "rain-math-float-0.1.1/src/lib/LibDecimalFloat.sol";
 
 bytes32 constant PRE = keccak256(abi.encodePacked("pre"));

--- a/test/abstract/OperandTest.sol
+++ b/test/abstract/OperandTest.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParse} from "../../src/lib/parse/LibParse.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";
 import {ParseState} from "../../src/lib/parse/LibParseState.sol";

--- a/test/abstract/ParseLiteralTest.sol
+++ b/test/abstract/ParseLiteralTest.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseState, ParseState} from "../../src/lib/parse/LibParseState.sol";
 import {LibParseLiteral, UnsupportedLiteralType} from "../../src/lib/parse/literal/LibParseLiteral.sol";

--- a/test/abstract/ParseTest.sol
+++ b/test/abstract/ParseTest.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";
 import {LibParse} from "../../src/lib/parse/LibParse.sol";
 import {ParseState} from "../../src/lib/parse/LibParseState.sol";

--- a/test/abstract/RainlangExpressionDeployerDeploymentTest.sol
+++ b/test/abstract/RainlangExpressionDeployerDeploymentTest.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {BaseRainlangStore} from "../../src/abstract/BaseRainlangStore.sol";
 import {BaseRainlangParser} from "../../src/abstract/BaseRainlangParser.sol";
 import {BaseRainlangInterpreter} from "../../src/abstract/BaseRainlangInterpreter.sol";

--- a/test/lib/deploy/LibTestInterpreterDeploy.sol
+++ b/test/lib/deploy/LibTestInterpreterDeploy.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {Vm} from "forge-std-1.16.2/src/Vm.sol";
 import {TestRainlangParser} from "../../concrete/TestRainlangParser.sol";
 import {TestRainlangStore} from "../../concrete/TestRainlangStore.sol";
 import {TestRainlangInterpreter} from "../../concrete/TestRainlangInterpreter.sol";

--- a/test/lib/string/LibCamelToKebab.t.sol
+++ b/test/lib/string/LibCamelToKebab.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibCamelToKebab} from "./LibCamelToKebab.sol";
 
 contract LibCamelToKebabTest is Test {

--- a/test/src/abstract/BaseRainlangExtern.construction.t.sol
+++ b/test/src/abstract/BaseRainlangExtern.construction.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {ExternPointersMismatch, ExternOpcodePointersEmpty} from "../../../src/error/ErrExtern.sol";
 import {EmptyPointersExtern} from "./EmptyPointersExtern.sol";
 import {MismatchedExternMoreOpcodes} from "./MismatchedExternMoreOpcodes.sol";

--- a/test/src/abstract/BaseRainlangExtern.ierc165.t.sol
+++ b/test/src/abstract/BaseRainlangExtern.ierc165.t.sol
@@ -2,11 +2,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {IInterpreterExternV4} from "rainlang-interface-0.2.8/src/interface/IInterpreterExternV4.sol";
-import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IIntegrityToolingV1.sol";
-import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IOpcodeToolingV1.sol";
+import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IIntegrityToolingV1.sol";
+import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IOpcodeToolingV1.sol";
 import {ChildRainlangExtern} from "./ChildRainlangExtern.sol";
 
 /// @title BaseRainlangExternTest

--- a/test/src/abstract/BaseRainlangExtern.integrityOpcodeRange.t.sol
+++ b/test/src/abstract/BaseRainlangExtern.integrityOpcodeRange.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {ExternDispatchV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterExternV4.sol";
 import {ExternOpcodeOutOfRange} from "../../../src/error/ErrExtern.sol";
 import {TwoOpExtern} from "./TwoOpExtern.sol";

--- a/test/src/abstract/BaseRainlangSubParser.ierc165.t.sol
+++ b/test/src/abstract/BaseRainlangSubParser.ierc165.t.sol
@@ -2,12 +2,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {ISubParserV4} from "rainlang-interface-0.2.8/src/interface/ISubParserV4.sol";
 import {IDescribedByMetaV1} from "rain-metadata-0.1.0/src/interface/IDescribedByMetaV1.sol";
-import {IParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IParserToolingV1.sol";
-import {ISubParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/ISubParserToolingV1.sol";
+import {IParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IParserToolingV1.sol";
+import {ISubParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/ISubParserToolingV1.sol";
 import {ChildRainlangSubParser} from "./ChildRainlangSubParser.sol";
 
 /// @title BaseRainlangSubParserTest

--- a/test/src/abstract/BaseRainlangSubParser.subParseLiteral2.t.sol
+++ b/test/src/abstract/BaseRainlangSubParser.subParseLiteral2.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {SubParserIndexOutOfBounds} from "../../../src/abstract/BaseRainlangSubParser.sol";
 
 /// @dev Simple literal parser that returns the dispatch value unchanged.

--- a/test/src/abstract/BaseRainlangSubParser.subParseWord2.t.sol
+++ b/test/src/abstract/BaseRainlangSubParser.subParseWord2.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {SubParserIndexOutOfBounds} from "../../../src/abstract/BaseRainlangSubParser.sol";
 import {MismatchedWordSubParser} from "./MismatchedWordSubParser.sol";
 import {EmptyWordParsersSubParser} from "./EmptyWordParsersSubParser.sol";

--- a/test/src/concrete/Rainlang.ierc165.t.sol
+++ b/test/src/concrete/Rainlang.ierc165.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {TestRainlang} from "test/concrete/TestRainlang.sol";

--- a/test/src/concrete/RainlangExpressionDeployer.ierc165.t.sol
+++ b/test/src/concrete/RainlangExpressionDeployer.ierc165.t.sol
@@ -2,14 +2,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {TestRainlangExpressionDeployer} from "test/concrete/TestRainlangExpressionDeployer.sol";
 import {IParserPragmaV1} from "rainlang-interface-0.2.8/src/interface/IParserPragmaV1.sol";
 import {IParserV2} from "rainlang-interface-0.2.8/src/interface/IParserV2.sol";
 import {IDescribedByMetaV1} from "rain-metadata-0.1.0/src/interface/IDescribedByMetaV1.sol";
-import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IIntegrityToolingV1.sol";
+import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IIntegrityToolingV1.sol";
 
 contract RainlangExpressionDeployerIERC165Test is Test {
     /// Test that ERC165 is implemented for all interfaces.

--- a/test/src/concrete/RainlangInterpreter.ierc165.t.sol
+++ b/test/src/concrete/RainlangInterpreter.ierc165.t.sol
@@ -2,12 +2,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {TestRainlangInterpreter} from "test/concrete/TestRainlangInterpreter.sol";
 import {IInterpreterV4} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
-import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IOpcodeToolingV1.sol";
+import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IOpcodeToolingV1.sol";
 
 contract RainlangInterpreterIERC165Test is Test {
     /// Test that ERC165 is implemented for all interfaces.

--- a/test/src/concrete/RainlangInterpreter.t.sol
+++ b/test/src/concrete/RainlangInterpreter.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibAllStandardOps} from "../../../src/lib/op/LibAllStandardOps.sol";
 

--- a/test/src/concrete/RainlangInterpreter.zeroFunctionPointers.t.sol
+++ b/test/src/concrete/RainlangInterpreter.zeroFunctionPointers.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {TestRainlangInterpreter} from "test/concrete/TestRainlangInterpreter.sol";
 import {ZeroFunctionPointers} from "../../../src/error/ErrEval.sol";

--- a/test/src/concrete/RainlangParser.ierc165.t.sol
+++ b/test/src/concrete/RainlangParser.ierc165.t.sol
@@ -2,11 +2,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {TestRainlangParser} from "test/concrete/TestRainlangParser.sol";
-import {IParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IParserToolingV1.sol";
+import {IParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IParserToolingV1.sol";
 
 contract RainlangParserIERC165Test is Test {
     /// Test that ERC165 is implemented for all interfaces.

--- a/test/src/concrete/RainlangParser.parseMemoryOverflow.t.sol
+++ b/test/src/concrete/RainlangParser.parseMemoryOverflow.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {ParseMemoryOverflow} from "../../../src/error/ErrParse.sol";
 import {ModifierTestParser} from "./ModifierTestParser.sol";

--- a/test/src/concrete/RainlangParser.parsePragmaEmpty.t.sol
+++ b/test/src/concrete/RainlangParser.parsePragmaEmpty.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangParser} from "test/concrete/TestRainlangParser.sol";
 import {PragmaV1} from "rainlang-interface-0.2.8/src/interface/IParserPragmaV1.sol";
 

--- a/test/src/concrete/RainlangParser.parserPragma.t.sol
+++ b/test/src/concrete/RainlangParser.parserPragma.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangParser} from "test/concrete/TestRainlangParser.sol";
 import {PragmaV1} from "rainlang-interface-0.2.8/src/interface/IParserPragmaV1.sol";
 import {NoWhitespaceAfterUsingWordsFrom} from "../../../src/error/ErrParse.sol";

--- a/test/src/concrete/RainlangReferenceExtern.bytecode.t.sol
+++ b/test/src/concrete/RainlangReferenceExtern.bytecode.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {RainlangReferenceExtern} from "../../../src/concrete/extern/RainlangReferenceExtern.sol";
 import {LibExtrospectBytecode} from "rain-extrospection-0.1.14/src/lib/LibExtrospectBytecode.sol";
 import {LibExtrospectMetamorphic} from "rain-extrospection-0.1.14/src/lib/LibExtrospectMetamorphic.sol";

--- a/test/src/concrete/RainlangReferenceExtern.describedByMetaV1.t.sol
+++ b/test/src/concrete/RainlangReferenceExtern.describedByMetaV1.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {RainlangReferenceExtern} from "../../../src/concrete/extern/RainlangReferenceExtern.sol";
 
 contract RainlangReferenceExternDescribedByMetaV1 is Test {

--- a/test/src/concrete/RainlangReferenceExtern.ierc165.t.sol
+++ b/test/src/concrete/RainlangReferenceExtern.ierc165.t.sol
@@ -2,17 +2,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {IInterpreterExternV4} from "rainlang-interface-0.2.8/src/interface/IInterpreterExternV4.sol";
 import {ISubParserV4} from "rainlang-interface-0.2.8/src/interface/ISubParserV4.sol";
 import {RainlangReferenceExtern} from "../../../src/concrete/extern/RainlangReferenceExtern.sol";
 import {IDescribedByMetaV1} from "rain-metadata-0.1.0/src/interface/IDescribedByMetaV1.sol";
-import {ISubParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/ISubParserToolingV1.sol";
-import {IParserToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IParserToolingV1.sol";
-import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IIntegrityToolingV1.sol";
-import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.0/src/interface/IOpcodeToolingV1.sol";
+import {ISubParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/ISubParserToolingV1.sol";
+import {IParserToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IParserToolingV1.sol";
+import {IIntegrityToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IIntegrityToolingV1.sol";
+import {IOpcodeToolingV1} from "rain-sol-codegen-0.1.36/src/interface/IOpcodeToolingV1.sol";
 
 contract RainlangReferenceExternIERC165Test is Test {
     /// Test that ERC165 is implemented for the reference extern contract.

--- a/test/src/concrete/RainlangReferenceExtern.pointers.t.sol
+++ b/test/src/concrete/RainlangReferenceExtern.pointers.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {
     RainlangReferenceExtern,
     OPCODE_FUNCTION_POINTERS,

--- a/test/src/concrete/RainlangReferenceExtern.subParserIndexOutOfBounds.t.sol
+++ b/test/src/concrete/RainlangReferenceExtern.subParserIndexOutOfBounds.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {SubParserIndexOutOfBounds} from "../../../src/error/ErrSubParse.sol";
 import {MockExternBadLiteralIndex} from "./MockExternBadLiteralIndex.sol";
 

--- a/test/src/concrete/RainlangStore.getUninitialized.t.sol
+++ b/test/src/concrete/RainlangStore.getUninitialized.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangStore} from "test/concrete/TestRainlangStore.sol";
 import {
     LibNamespace,

--- a/test/src/concrete/RainlangStore.ierc165.t.sol
+++ b/test/src/concrete/RainlangStore.ierc165.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {IERC165} from "@openzeppelin-contracts-5.6.1/utils/introspection/IERC165.sol";
 import {TestRainlangStore} from "test/concrete/TestRainlangStore.sol";

--- a/test/src/concrete/RainlangStore.namespaceIsolation.t.sol
+++ b/test/src/concrete/RainlangStore.namespaceIsolation.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangStore} from "test/concrete/TestRainlangStore.sol";
 import {
     LibNamespace,

--- a/test/src/concrete/RainlangStore.overwriteKey.t.sol
+++ b/test/src/concrete/RainlangStore.overwriteKey.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangStore} from "test/concrete/TestRainlangStore.sol";
 import {
     LibNamespace,

--- a/test/src/concrete/RainlangStore.setEmpty.t.sol
+++ b/test/src/concrete/RainlangStore.setEmpty.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangStore} from "test/concrete/TestRainlangStore.sol";
 import {StateNamespace} from "rainlang-interface-0.2.8/src/lib/ns/LibNamespace.sol";
 

--- a/test/src/concrete/RainlangStore.setEvent.t.sol
+++ b/test/src/concrete/RainlangStore.setEvent.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangStore} from "test/concrete/TestRainlangStore.sol";
 import {
     LibNamespace,

--- a/test/src/concrete/RainlangStore.t.sol
+++ b/test/src/concrete/RainlangStore.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {Address} from "@openzeppelin-contracts-5.6.1/utils/Address.sol";
 import {LibBytes32Array} from "rain-solmem-0.1.28/src/lib/LibBytes32Array.sol";
 import {LibUint256Array} from "rain-solmem-0.1.28/src/lib/LibUint256Array.sol";

--- a/test/src/lib/eval/LibEval.fBounds.t.sol
+++ b/test/src/lib/eval/LibEval.fBounds.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibInterpreterState, InterpreterState} from "../../../../src/lib/state/LibInterpreterState.sol";
 import {LibAllStandardOps} from "../../../../src/lib/op/LibAllStandardOps.sol";

--- a/test/src/lib/eval/LibEval.inputsLengthMismatch.t.sol
+++ b/test/src/lib/eval/LibEval.inputsLengthMismatch.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibInterpreterState, InterpreterState} from "../../../../src/lib/state/LibInterpreterState.sol";
 import {LibAllStandardOps} from "../../../../src/lib/op/LibAllStandardOps.sol";

--- a/test/src/lib/extern/LibExtern.codec.t.sol
+++ b/test/src/lib/extern/LibExtern.codec.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {
     LibExtern,

--- a/test/src/lib/extern/reference/literal/LibParseLiteralRepeat.t.sol
+++ b/test/src/lib/extern/reference/literal/LibParseLiteralRepeat.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {
     LibParseLiteralRepeat,

--- a/test/src/lib/extern/reference/op/LibExternOpContextCallingContract.subParser.t.sol
+++ b/test/src/lib/extern/reference/op/LibExternOpContextCallingContract.subParser.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OPCODE_CONTEXT, OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {
     CONTEXT_BASE_COLUMN,

--- a/test/src/lib/extern/reference/op/LibExternOpContextRainlen.subParser.t.sol
+++ b/test/src/lib/extern/reference/op/LibExternOpContextRainlen.subParser.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OPCODE_CONTEXT, OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {
     LibExternOpContextRainlen,

--- a/test/src/lib/extern/reference/op/LibExternOpContextSender.subParser.t.sol
+++ b/test/src/lib/extern/reference/op/LibExternOpContextSender.subParser.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OPCODE_CONTEXT, OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {CONTEXT_BASE_COLUMN, CONTEXT_BASE_ROW_SENDER} from "rainlang-interface-0.2.8/src/lib/caller/LibContext.sol";
 import {LibExternOpContextSender} from "../../../../../../src/lib/extern/reference/op/LibExternOpContextSender.sol";

--- a/test/src/lib/extern/reference/op/LibExternOpStackOperand.subParser.t.sol
+++ b/test/src/lib/extern/reference/op/LibExternOpStackOperand.subParser.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OPCODE_CONSTANT, OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {LibExternOpStackOperand} from "../../../../../../src/lib/extern/reference/op/LibExternOpStackOperand.sol";
 

--- a/test/src/lib/integrity/LibIntegrityCheck.newState.t.sol
+++ b/test/src/lib/integrity/LibIntegrityCheck.newState.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibIntegrityCheck, IntegrityCheckState} from "../../../../src/lib/integrity/LibIntegrityCheck.sol";
 
 /// @title LibIntegrityCheckNewStateTest

--- a/test/src/lib/integrity/LibIntegrityCheck.t.sol
+++ b/test/src/lib/integrity/LibIntegrityCheck.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibIntegrityCheck} from "../../../../src/lib/integrity/LibIntegrityCheck.sol";
 import {
     OpcodeOutOfRange,

--- a/test/src/lib/op/00/LibOpContext.t.sol
+++ b/test/src/lib/op/00/LibOpContext.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {stdError} from "forge-std-1.16.1/src/Test.sol";
+import {stdError} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibOpContext} from "../../../../../src/lib/op/00/LibOpContext.sol";
 import {OpTest} from "test/abstract/OpTest.sol";

--- a/test/src/lib/op/LibAllStandardOps.filesystemOrdering.t.sol
+++ b/test/src/lib/op/LibAllStandardOps.filesystemOrdering.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibAllStandardOps, ALL_STANDARD_OPS_LENGTH} from "../../../../src/lib/op/LibAllStandardOps.sol";
 import {AuthoringMetaV2} from "rainlang-interface-0.2.8/src/interface/IParserV2.sol";
 import {LibCamelToKebab} from "test/lib/string/LibCamelToKebab.sol";

--- a/test/src/lib/op/LibAllStandardOps.t.sol
+++ b/test/src/lib/op/LibAllStandardOps.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibAllStandardOps, ALL_STANDARD_OPS_LENGTH} from "../../../../src/lib/op/LibAllStandardOps.sol";
 import {AuthoringMetaV2} from "rainlang-interface-0.2.8/src/interface/IParserV2.sol";

--- a/test/src/lib/op/math/LibOpMul.t.sol
+++ b/test/src/lib/op/math/LibOpMul.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {console2} from "forge-std-1.16.1/src/Test.sol";
+import {console2} from "forge-std-1.16.2/src/Test.sol";
 import {LibOpMul} from "../../../../../src/lib/op/math/LibOpMul.sol";
 import {OpTest, IntegrityCheckState, OperandV2} from "test/abstract/OpTest.sol";
 import {LibOperand} from "test/lib/operand/LibOperand.sol";

--- a/test/src/lib/op/math/uint256/LibOpUint256Power.t.sol
+++ b/test/src/lib/op/math/uint256/LibOpUint256Power.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {stdError} from "forge-std-1.16.1/src/Test.sol";
+import {stdError} from "forge-std-1.16.2/src/Test.sol";
 import {OpTest} from "test/abstract/OpTest.sol";
 import {LibOpUint256Power} from "../../../../../../src/lib/op/math/uint256/LibOpUint256Power.sol";
 import {IntegrityCheckState} from "../../../../../../src/lib/integrity/LibIntegrityCheck.sol";

--- a/test/src/lib/parse/LibParse.empty.gas.t.sol
+++ b/test/src/lib/parse/LibParse.empty.gas.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";

--- a/test/src/lib/parse/LibParse.ignoredLHS.t.sol
+++ b/test/src/lib/parse/LibParse.ignoredLHS.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";

--- a/test/src/lib/parse/LibParse.inputsOnly.gas.t.sol
+++ b/test/src/lib/parse/LibParse.inputsOnly.gas.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";

--- a/test/src/lib/parse/LibParse.inputsOnly.t.sol
+++ b/test/src/lib/parse/LibParse.inputsOnly.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {LibBytecode} from "rainlang-interface-0.2.8/src/lib/bytecode/LibBytecode.sol";

--- a/test/src/lib/parse/LibParse.lhsOverflow.t.sol
+++ b/test/src/lib/parse/LibParse.lhsOverflow.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {TestRainlangParser} from "test/concrete/TestRainlangParser.sol";
 import {LHSItemCountOverflow} from "../../../../src/error/ErrParse.sol";
 

--- a/test/src/lib/parse/LibParse.literalIntegerHex.t.sol
+++ b/test/src/lib/parse/LibParse.literalIntegerHex.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";

--- a/test/src/lib/parse/LibParse.literalString.t.sol
+++ b/test/src/lib/parse/LibParse.literalString.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytecode} from "rainlang-interface-0.2.8/src/lib/bytecode/LibBytecode.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";

--- a/test/src/lib/parse/LibParse.parseMemoryOverflow.t.sol
+++ b/test/src/lib/parse/LibParse.parseMemoryOverflow.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";

--- a/test/src/lib/parse/LibParse.parseWord.t.sol
+++ b/test/src/lib/parse/LibParse.parseWord.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {Pointer, LibBytes} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseSlow} from "./LibParseSlow.sol";

--- a/test/src/lib/parse/LibParse.singleIgnored.gas.t.sol
+++ b/test/src/lib/parse/LibParse.singleIgnored.gas.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";

--- a/test/src/lib/parse/LibParse.singleLHSNamed.gas.t.sol
+++ b/test/src/lib/parse/LibParse.singleLHSNamed.gas.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 

--- a/test/src/lib/parse/LibParse.singleRHSNamed.gas.t.sol
+++ b/test/src/lib/parse/LibParse.singleRHSNamed.gas.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {AuthoringMetaV2} from "rainlang-interface-0.2.8/src/interface/IParserV2.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {OperandV2, LibParseOperand} from "../../../../src/lib/parse/LibParseOperand.sol";

--- a/test/src/lib/parse/LibParse.sourceInputs.t.sol
+++ b/test/src/lib/parse/LibParse.sourceInputs.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";

--- a/test/src/lib/parse/LibParse.unexpectedRightParen.t.sol
+++ b/test/src/lib/parse/LibParse.unexpectedRightParen.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";

--- a/test/src/lib/parse/LibParse.wordsRHS.t.sol
+++ b/test/src/lib/parse/LibParse.wordsRHS.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";

--- a/test/src/lib/parse/LibParseError.t.sol
+++ b/test/src/lib/parse/LibParseError.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibParseError, MAGIC_NUMBER_RAIN_PARSE_ERROR_V1} from "../../../../src/lib/parse/LibParseError.sol";
 import {LibAllStandardOps} from "../../../../src/lib/op/LibAllStandardOps.sol";

--- a/test/src/lib/parse/LibParseInterstitial.t.sol
+++ b/test/src/lib/parse/LibParseInterstitial.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibParseInterstitial} from "../../../../src/lib/parse/LibParseInterstitial.sol";

--- a/test/src/lib/parse/LibParseOperand.handleOperand.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperand.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibAllStandardOps} from "../../../../src/lib/op/LibAllStandardOps.sol";

--- a/test/src/lib/parse/LibParseOperand.handleOperand8M1M1.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperand8M1M1.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {ExpectedOperand, UnexpectedOperandValue} from "../../../../src/error/ErrParse.sol";
 import {OperandOverflow} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibParseOperand.handleOperandDisallowed.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperandDisallowed.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {UnexpectedOperand} from "../../../../src/error/ErrParse.sol";
 

--- a/test/src/lib/parse/LibParseOperand.handleOperandDisallowedAlwaysOne.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperandDisallowedAlwaysOne.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {UnexpectedOperand} from "../../../../src/error/ErrParse.sol";
 

--- a/test/src/lib/parse/LibParseOperand.handleOperandDoublePerByteNoDefault.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperandDoublePerByteNoDefault.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {ExpectedOperand, UnexpectedOperandValue} from "../../../../src/error/ErrParse.sol";
 import {OperandOverflow} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibParseOperand.handleOperandM1M1.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperandM1M1.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {UnexpectedOperandValue} from "../../../../src/error/ErrParse.sol";
 import {OperandOverflow} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibParseOperand.handleOperandSingleFull.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperandSingleFull.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {UnexpectedOperandValue} from "../../../../src/error/ErrParse.sol";
 import {OperandOverflow} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibParseOperand.handleOperandSingleFullNoDefault.t.sol
+++ b/test/src/lib/parse/LibParseOperand.handleOperandSingleFullNoDefault.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand, OperandV2} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {UnexpectedOperandValue, ExpectedOperand} from "../../../../src/error/ErrParse.sol";
 import {OperandOverflow} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibParseOperand.parseOperand.t.sol
+++ b/test/src/lib/parse/LibParseOperand.parseOperand.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseOperand} from "../../../../src/lib/parse/LibParseOperand.sol";
 import {ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";

--- a/test/src/lib/parse/LibParsePragma.keyword.t.sol
+++ b/test/src/lib/parse/LibParsePragma.keyword.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibParseState, ParseState, SUB_PARSER_POINTER_SHIFT} from "../../../../src/lib/parse/LibParseState.sol";
 import {

--- a/test/src/lib/parse/LibParseStackName.t.sol
+++ b/test/src/lib/parse/LibParseStackName.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {ParseState, LibParseStackName} from "../../../../src/lib/parse/LibParse.sol";
 

--- a/test/src/lib/parse/LibParseStackTracker.t.sol
+++ b/test/src/lib/parse/LibParseStackTracker.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseStackTracker, ParseStackTracker} from "../../../../src/lib/parse/LibParseStackTracker.sol";
 import {ParseStackOverflow, ParseStackUnderflow} from "../../../../src/error/ErrParse.sol";
 

--- a/test/src/lib/parse/LibParseState.buildBytecode.t.sol
+++ b/test/src/lib/parse/LibParseState.buildBytecode.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState, EMPTY_ACTIVE_SOURCE} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibBytecode} from "rainlang-interface-0.2.8/src/lib/bytecode/LibBytecode.sol";
 import {OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";

--- a/test/src/lib/parse/LibParseState.buildConstants.t.sol
+++ b/test/src/lib/parse/LibParseState.buildConstants.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 
 /// @title LibParseStateBuildConstantsTest

--- a/test/src/lib/parse/LibParseState.checkParseMemoryOverflow.t.sol
+++ b/test/src/lib/parse/LibParseState.checkParseMemoryOverflow.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {ParseMemoryOverflow} from "../../../../src/error/ErrParse.sol";
 

--- a/test/src/lib/parse/LibParseState.constantValueBloom.t.sol
+++ b/test/src/lib/parse/LibParseState.constantValueBloom.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.18;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibCtPop} from "rain-math-binary-0.1.4/src/lib/LibCtPop.sol";
 

--- a/test/src/lib/parse/LibParseState.danglingSource.t.sol
+++ b/test/src/lib/parse/LibParseState.danglingSource.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {DanglingSource} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibParseState.endLine.unboundedLHS.t.sol
+++ b/test/src/lib/parse/LibParseState.endLine.unboundedLHS.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {ParseState} from "../../../../src/lib/parse/LibParseState.sol";

--- a/test/src/lib/parse/LibParseState.endSource.t.sol
+++ b/test/src/lib/parse/LibParseState.endSource.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {
     LibParseState,
     ParseState,

--- a/test/src/lib/parse/LibParseState.exportSubParsers.t.sol
+++ b/test/src/lib/parse/LibParseState.exportSubParsers.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.18;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 

--- a/test/src/lib/parse/LibParseState.highwaterOverflow.t.sol
+++ b/test/src/lib/parse/LibParseState.highwaterOverflow.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {ParseStackOverflow} from "../../../../src/error/ErrParse.sol";
 

--- a/test/src/lib/parse/LibParseState.newActiveSourcePointer.t.sol
+++ b/test/src/lib/parse/LibParseState.newActiveSourcePointer.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {EMPTY_ACTIVE_SOURCE, LibParseState} from "../../../../src/lib/parse/LibParseState.sol";
 
 contract LibParseStateNewActiveSourcePointerTest is Test {

--- a/test/src/lib/parse/LibParseState.offsets.t.sol
+++ b/test/src/lib/parse/LibParseState.offsets.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {
     ParseState,
     PARSE_STATE_TOP_LEVEL0_OFFSET,

--- a/test/src/lib/parse/LibParseState.parenInputOverflow.t.sol
+++ b/test/src/lib/parse/LibParseState.parenInputOverflow.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {ParenInputOverflow} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibParseState.pushConstantValue.t.sol
+++ b/test/src/lib/parse/LibParseState.pushConstantValue.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.18;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 
 /// @title LibParseStatePushConstantValueTest

--- a/test/src/lib/parse/LibParseState.pushLiteral.t.sol
+++ b/test/src/lib/parse/LibParseState.pushLiteral.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibAllStandardOps} from "../../../../src/lib/op/LibAllStandardOps.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";

--- a/test/src/lib/parse/LibParseState.pushOpToSource.LHSCorruption.t.sol
+++ b/test/src/lib/parse/LibParseState.pushOpToSource.LHSCorruption.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 

--- a/test/src/lib/parse/LibParseState.pushOpToSource.t.sol
+++ b/test/src/lib/parse/LibParseState.pushOpToSource.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {
     LibParseState,
     ParseState,

--- a/test/src/lib/parse/LibParseState.pushOpToSourceLHSCorruption.t.sol
+++ b/test/src/lib/parse/LibParseState.pushOpToSourceLHSCorruption.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState, MAX_STACK_RHS_OFFSET} from "../../../../src/lib/parse/LibParseState.sol";
 import {OperandV2} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 

--- a/test/src/lib/parse/LibParseState.pushSubParser.largeMemory.t.sol
+++ b/test/src/lib/parse/LibParseState.pushSubParser.largeMemory.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 

--- a/test/src/lib/parse/LibParseState.pushSubParser.t.sol
+++ b/test/src/lib/parse/LibParseState.pushSubParser.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState, SUB_PARSER_POINTER_SHIFT} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {InvalidSubParser} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/LibSubParse.constantAccumulation.t.sol
+++ b/test/src/lib/parse/LibSubParse.constantAccumulation.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {LibMetaFixture} from "test/lib/parse/LibMetaFixture.sol";

--- a/test/src/lib/parse/LibSubParse.consumeSubParseLiteralInputData.t.sol
+++ b/test/src/lib/parse/LibSubParse.consumeSubParseLiteralInputData.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibSubParse} from "../../../../src/lib/parse/LibSubParse.sol";
 
 /// @title LibSubParseConsumeSubParseLiteralInputDataTest

--- a/test/src/lib/parse/LibSubParse.consumeSubParseWordInputData.t.sol
+++ b/test/src/lib/parse/LibSubParse.consumeSubParseWordInputData.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibSubParse} from "../../../../src/lib/parse/LibSubParse.sol";
 import {ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 

--- a/test/src/lib/parse/LibSubParse.subParseLiteral.t.sol
+++ b/test/src/lib/parse/LibSubParse.subParseLiteral.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibSubParse} from "../../../../src/lib/parse/LibSubParse.sol";
 import {Pointer} from "rain-solmem-0.1.28/src/lib/LibPointer.sol";

--- a/test/src/lib/parse/LibSubParse.subParseWords.t.sol
+++ b/test/src/lib/parse/LibSubParse.subParseWords.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibSubParse} from "../../../../src/lib/parse/LibSubParse.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";

--- a/test/src/lib/parse/LibSubParse.subParserConstant.t.sol
+++ b/test/src/lib/parse/LibSubParse.subParserConstant.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OPCODE_CONSTANT} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {LibSubParse} from "../../../../src/lib/parse/LibSubParse.sol";
 import {ConstantOpcodeConstantsHeightOverflow} from "../../../../src/error/ErrSubParse.sol";

--- a/test/src/lib/parse/LibSubParse.subParserContext.t.sol
+++ b/test/src/lib/parse/LibSubParse.subParserContext.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OPCODE_CONTEXT} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {LibSubParse} from "../../../../src/lib/parse/LibSubParse.sol";
 import {ContextGridOverflow} from "../../../../src/error/ErrSubParse.sol";

--- a/test/src/lib/parse/LibSubParse.subParserExtern.t.sol
+++ b/test/src/lib/parse/LibSubParse.subParserExtern.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {OperandV2, OPCODE_EXTERN} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";
 import {
     IInterpreterExternV4,

--- a/test/src/lib/parse/LibSubParse.unknownWord.t.sol
+++ b/test/src/lib/parse/LibSubParse.unknownWord.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseState, ParseState} from "../../../../src/lib/parse/LibParseState.sol";
 import {LibParse} from "../../../../src/lib/parse/LibParse.sol";
 import {UnknownWord} from "../../../../src/error/ErrParse.sol";

--- a/test/src/lib/parse/literal/LibParseLiteral.dispatch.t.sol
+++ b/test/src/lib/parse/literal/LibParseLiteral.dispatch.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseState, ParseState} from "../../../../../src/lib/parse/LibParseState.sol";
 import {LibParseLiteral, UnsupportedLiteralType} from "../../../../../src/lib/parse/literal/LibParseLiteral.sol";

--- a/test/src/lib/parse/literal/LibParseLiteral.selectByIndex.t.sol
+++ b/test/src/lib/parse/literal/LibParseLiteral.selectByIndex.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseState, ParseState} from "../../../../../src/lib/parse/LibParseState.sol";
 import {LibParseLiteral} from "../../../../../src/lib/parse/literal/LibParseLiteral.sol";

--- a/test/src/lib/parse/literal/LibParseLiteralDecimal.parseDecimalFloat.t.sol
+++ b/test/src/lib/parse/literal/LibParseLiteralDecimal.parseDecimalFloat.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 import {LibParseState, ParseState} from "../../../../../src/lib/parse/LibParseState.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";

--- a/test/src/lib/parse/literal/LibParseLiteralHex.parseHex.t.sol
+++ b/test/src/lib/parse/literal/LibParseLiteralHex.parseHex.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";
 import {LibParseState, ParseState} from "../../../../../src/lib/parse/LibParseState.sol";

--- a/test/src/lib/parse/literal/LibParseLiteralString.boundString.t.sol
+++ b/test/src/lib/parse/literal/LibParseLiteralString.boundString.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseLiteralString} from "../../../../../src/lib/parse/literal/LibParseLiteralString.sol";
 import {LibConformString} from "rain-string-0.2.0/src/lib/mut/LibConformString.sol";

--- a/test/src/lib/parse/literal/LibParseLiteralString.parseString.t.sol
+++ b/test/src/lib/parse/literal/LibParseLiteralString.parseString.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibParseLiteralString} from "../../../../../src/lib/parse/literal/LibParseLiteralString.sol";
 import {LibBytes, Pointer} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {IntOrAString, LibIntOrAString} from "rain-intorastring-0.1.0/src/lib/LibIntOrAString.sol";

--- a/test/src/lib/parse/literal/LibParseLiteralSubParseable.parseSubParseable.t.sol
+++ b/test/src/lib/parse/literal/LibParseLiteralSubParseable.parseSubParseable.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test, console2} from "forge-std-1.16.1/src/Test.sol";
+import {Test, console2} from "forge-std-1.16.2/src/Test.sol";
 import {ParseState, Pointer, LibParseState} from "../../../../../src/lib/parse/LibParseState.sol";
 import {LibBytes} from "rain-solmem-0.1.28/src/lib/LibBytes.sol";
 import {LibParseLiteralSubParseable} from "../../../../../src/lib/parse/literal/LibParseLiteralSubParseable.sol";

--- a/test/src/lib/state/LibInterpreterState.fingerprint.t.sol
+++ b/test/src/lib/state/LibInterpreterState.fingerprint.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {InterpreterState} from "../../../../src/lib/state/LibInterpreterState.sol";
 import {LibInterpreterStateFingerprint} from "test/lib/state/LibInterpreterStateFingerprint.sol";
 import {Pointer} from "rain-solmem-0.1.28/src/lib/LibPointer.sol";

--- a/test/src/lib/state/LibInterpreterState.stackBottoms.t.sol
+++ b/test/src/lib/state/LibInterpreterState.stackBottoms.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibInterpreterState} from "../../../../src/lib/state/LibInterpreterState.sol";
 import {Pointer} from "rain-solmem-0.1.28/src/lib/LibPointer.sol";
 import {StackItem} from "rainlang-interface-0.2.8/src/interface/IInterpreterV4.sol";

--- a/test/src/lib/state/LibInterpreterState.stackTrace.t.sol
+++ b/test/src/lib/state/LibInterpreterState.stackTrace.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {LibUint256Array} from "rain-solmem-0.1.28/src/lib/LibUint256Array.sol";
 import {LibInterpreterState, STACK_TRACER} from "../../../../src/lib/state/LibInterpreterState.sol";
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 
 contract LibInterpreterStateStackTraceTest is Test {
     using LibUint256Array for uint256[];

--- a/test/src/lib/state/LibInterpreterStateDataContract.t.sol
+++ b/test/src/lib/state/LibInterpreterStateDataContract.t.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity =0.8.25;
 
-import {Test} from "forge-std-1.16.1/src/Test.sol";
+import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {LibInterpreterStateDataContract} from "../../../../src/lib/state/LibInterpreterStateDataContract.sol";
 import {InterpreterState} from "../../../../src/lib/state/LibInterpreterState.sol";
 import {Pointer} from "rain-solmem-0.1.28/src/lib/LibPointer.sol";


### PR DESCRIPTION
Every import now spells the version `foundry.toml` pins: `forge-std-1.16.1/` -> `forge-std-1.16.2/` and `rain-sol-codegen-0.1.0/` -> `rain-sol-codegen-0.1.36/` across `src`, `test` and `script`, and the `remappings` block that aliased the older prefixes onto the installed packages is gone.

An alias makes a file compile against a version it does not name, so the versioned prefix stops being the pin. It also leaked downstream: every consumer of this package had to carry the same two aliases to compile the shipped `test/abstract` harness and the tooling interfaces. With the package spelling what it pins, consumers pin `forge-std` 1.16.2 and `rain-sol-codegen` 0.1.36 and nothing else.

No source change beyond import paths. The `rain-sol-codegen` 0.1.36 tooling interfaces widen three functions from `pure` to `view`; the implementations here keep `pure`, which overrides narrow. `script/Build.sol` regenerates the reference extern pointers byte-identically.

## QA

- Discriminating tests: the full suite, unchanged in count, with only the `ARBITRUM_RPC_URL` fork fixtures failing locally as on `main`. The build itself is the discriminating check: with the alias block gone, any import still spelling a prefix that is not installed fails to resolve.
- Mutations applied: n/a, import paths only.
- Oracle: `foundry.toml` `[dependencies]`, which the imports now match one-to-one; `forge remappings` shows no alias.
- Category check: the ruling "you can't remap versions" on rain.dia#72; this is the upstream fix it requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyCCzi9WZPhuXcU1hwr2bq
